### PR TITLE
Join Missions

### DIFF
--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -6,7 +6,7 @@ import TableHead from '@material-ui/core/TableHead';
 import TableBody from '@material-ui/core/TableBody';
 import TableRow from '@material-ui/core/TableRow';
 import TableCell from '@material-ui/core/TableCell';
-import { getMissions } from '../redux/missions/missions';
+import { getMissions, joinMissions } from '../redux/missions/missions';
 import style from './Missions.module.css';
 
 const Missions = () => {
@@ -33,7 +33,7 @@ const Missions = () => {
               <TableCell className={style.missionName}>{mission.mission_name}</TableCell>
               <TableCell className={style.descriptionText}>{mission.description}</TableCell>
               <TableCell className={style.missionStatus}><button disabled type="button" className="statusBtn">NOT A MEMBER</button></TableCell>
-              <TableCell className={style.membership}><button type="button" className="membershipBtn">Join Mission</button></TableCell>
+              <TableCell className={style.membership}><button type="button" className="membershipBtn" onClick={() => dispatch(joinMissions(mission.id))}>Join Mission</button></TableCell>
             </TableRow>
           ))}
         </TableBody>

--- a/src/redux/missions/missions.js
+++ b/src/redux/missions/missions.js
@@ -2,6 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import fetchMissions from './fetch';
 
 const GET_MISSIONS = 'Missions/Missions/GET_MISSIONS';
+const JOIN_MISSIONS = 'Missions/Missions/JOIN_MISSIONS';
 
 const initialState = {
   missions: [],
@@ -29,6 +30,17 @@ export const getMissions = createAsyncThunk(GET_MISSIONS, async () => {
   });
 
   return missions;
+});
+
+export const joinMissions = createAsyncThunk(JOIN_MISSIONS, async (id) => {
+  const data = await fetchMissions();
+  const newState = data.map((mission) => {
+    if (mission.id !== id) {
+      return mission;
+    }
+    return { ...mission, reserved: true };
+  });
+  return newState;
 });
 
 export default missionReducer;


### PR DESCRIPTION
## Milestone: Mission joining action
*The following changes are being introduced:*
- When a user clicks the "Join Mission" button, an action is dispatched to update the store.
- A selected mission has an extra key `reserved` with its value set to `true`

**This resolves issue #11**